### PR TITLE
[Feat] 메인 대시보드 UI 및 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -166,3 +166,4 @@ export default function App() {
     </ToastProvider>
   );
 }
+//

--- a/src/Data/data.jsx
+++ b/src/Data/data.jsx
@@ -163,3 +163,4 @@ export const generateDummyLogs = (userId) => {
     };
   }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp)); // 생성된 로그를 최신순으로 정렬함.
 };
+//

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -220,3 +220,4 @@ export default function DashboardPage({ onGotoRetrain, queueItems, setPageTitle,
     </>
   );
 }
+//

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -252,3 +252,4 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,"Noto Sa
 }
 @keyframes toast-in { from { transform: translateX(100%); opacity: 0;} to { transform: translateX(0); opacity: 1;}}
 @keyframes toast-out { from { transform: translateX(0); opacity: 1;} to {transform: translateX(100%); opacity: 0;}}
+/**/


### PR DESCRIPTION
## 🔗 관련 이슈
Issue #3

---

## ✨ 변경 내용
- 관리자가 로그인 후 보게 될 메인 대시보드 페이지(`DashboardPage.jsx`)의 전체 UI를 구현해야 함.
- KPI, API 호출 횟수 차트, API 호출 시간 순위, AI 재학습 요약 등 4개의 주요 섹션을 `data.jsx`의 더미 데이터를 기반으로 렌더링해야 함.
- `App.jsx`에 대시보드 페이지로 연결되는 라우트를 설정하고, 필요한 데이터(`queueItems`)와 함수(`onGotoUserManagement`)를 props로 전달해야 함.

---

## 🧪 테스트 방법
- [ ] **1. 기본 렌더링 확인**: 로그인 후 대시보드 페이지로 이동했을 때, KPI 카드 4개, API 호출 횟수 막대그래프, API 호출 시간 순위 목록, AI 재학습 요약 섹션이 모두 정상적으로 표시되는지 확인해야 함.
- [ ] **2. KPI 카드 네비게이션 테스트**: '차단 유저 수' 카드를 클릭했을 때, 주소가 `/user?status=BLOCKED`로 이동하는지 확인해야 함. '정지 유저 수' 카드를 클릭했을 때 `/user?status=SUSPENDED`로 이동하는지 확인해야 함.
- [ ] **3. API 차트 상호작용 테스트**: '총 API 호출 횟수' 섹션의 각 막대에 마우스를 올렸을 때, 해당 막대 상단에 호출 횟수를 나타내는 툴팁이 나타나는지 확인해야 함. 막대 중 하나를 클릭했을 때, 오른쪽에 해당 날짜의 상세 API 호출 내역 패널이 나타나는지 확인해야 함.
- [ ] **4. AI 재학습 요약 팝오버 테스트**: 'AI 재학습 검토 대기열' 목록에서 감정 index가 2개를 초과하는 항목의 `+N` 버튼을 클릭했을 때, 나머지 감정 목록을 보여주는 팝오버가 정상적으로 나타나는지 확인해야 함.

---

## 👀 리뷰 포인트
- `DashboardPage.jsx` 내에서 `useMemo`를 사용하여 `apiSorted`와 `sortedApiDetails` 데이터를 계산하는 방식이 성능 최적화에 적절한지 검토해야 함.
- KPI 카드 클릭 시 `onGotoUserManagement` 함수를 통해 URL 쿼리 파라미터를 넘겨주는 방식이 올바르게 구현되었는지 확인해야 함.
- `hoveredBar`와 `selectedDay` `useState`를 통해 차트의 상호작용(호버, 클릭)을 제어하는 로직이 명확한지 검토해야 함.

---

## 📎 기타 참고 사항
- 모든 데이터는 앞으로 API 연동하면 `data.jsx` 파일을 API를 사용해서 data를 가져오는 파일로 만들고 싶음. 여기서 `import`하여 사용하고자함.