### PR TITLE
[Feat] 유저별 상세 대화 로그 조회 모달 기능 구현

### DIFF
--- a/src/Data/data.jsx
+++ b/src/Data/data.jsx
@@ -163,3 +163,4 @@ export const generateDummyLogs = (userId) => {
     };
   }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp)); // 생성된 로그를 최신순으로 정렬함.
 };
+//

--- a/src/components/UserChatLog.jsx
+++ b/src/components/UserChatLog.jsx
@@ -56,3 +56,4 @@ export default function UserChatLog({ user, onClose }) {
     </>
   );
 }
+//

--- a/src/pages/UserManagementPage.jsx
+++ b/src/pages/UserManagementPage.jsx
@@ -210,3 +210,4 @@ export default function UserManagementPage({ users, setUsers, setPageTitle }) {
     </>
   );
 }
+//

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -252,3 +252,4 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,"Noto Sa
 }
 @keyframes toast-in { from { transform: translateX(100%); opacity: 0;} to { transform: translateX(0); opacity: 1;}}
 @keyframes toast-out { from { transform: translateX(0); opacity: 1;} to {transform: translateX(100%); opacity: 0;}}
+/**/


### PR DESCRIPTION
- UserChatLog.jsx 모달 컴포넌트 추가

- UserManagementPage.jsx에 모달 트리거 로직 연결

## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
Issue #5

---

## ✨ 변경 내용
- 유저 관리 페이지에서 특정 유저의 대화 내역을 확인할 수 있는 `UserChatLog.jsx` 사이드 패널 모달을 구현해야 함.
- `UserManagementPage.jsx`의 말풍선 아이콘 클릭 시, `viewingUserLog` 상태를 업데이트하여 해당 모달을 동적으로 렌더링하도록 구현해야 함.
- 현재 모든 대화 로그는 `data.jsx`의 `generateDummyLogs` 함수를 통해 생성되며, `useMemo` 훅을 사용하여 성능을 최적화해야 함.

---

## 🧪 테스트 방법
- [ ] **1. 모달 열기 테스트**: 유저 관리 페이지(`/user`)로 이동하여, 임의의 유저 행에 있는 **말풍선 모양 아이콘**을 클릭해야 함.
- [ ] **2. 데이터 확인 테스트**: 화면 오른쪽에 해당 유저의 ID, 이름, 상태, 이메일 정보와 함께 더미 대화 로그 목록이 나타나는지 확인해야 함.
- [ ] **3. 유해 메시지 스타일 확인**: 대화 로그 중 "폭력적인", "해킹하는" 등의 단어가 포함된 메시지는 다른 배경색으로 강조 표시되는지 확인해야 함.
- [ ] **4. 모달 닫기 테스트**: 모달의 'X' 버튼을 누르거나, 모달 바깥의 어두운 배경을 클릭했을 때 모달이 정상적으로 닫히는지 확인해야 함.

---

## 👀 리뷰 포인트
- `UserManagementPage.jsx`에서 `viewingUserLog` 상태를 통해 `UserChatLog` 컴포넌트의 렌더링을 제어하는 방식이 적절한지 검토해야 함.
- `UserChatLog.jsx`에서 `user.id`가 변경될 때만 더미 로그를 재생성하도록 `useMemo` 훅을 사용한 최적화 로직을 중점적으로 검토해야 함.
- `isViolation` 값에 따라 `.violation` 클래스를 동적으로 부여하여 CSS로 스타일을 분기하는 방식이 올바른지 확인해야 함.

---

## 📎 기타 참고 사항
- 이번 PR은 **4개 파일(`UserChatLog.jsx`, `UserManagementPage.jsx`, `data.jsx`, `index.css`)** 에 대한 변경사항만을 포함해야 함.
- 모든 대화 로그 데이터는 API 연동 없이 `data.jsx` 파일의 더미 데이터를 기반으로 **클라이언트 사이드에서만** 동작함.