### PR TITLE
[Feat] AI 재학습 데이터 목록 및 수정 흐름 제어 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -166,3 +166,4 @@ export default function App() {
     </ToastProvider>
   );
 }
+//

--- a/src/Data/data.jsx
+++ b/src/Data/data.jsx
@@ -163,3 +163,4 @@ export const generateDummyLogs = (userId) => {
     };
   }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp)); // 생성된 로그를 최신순으로 정렬함.
 };
+//

--- a/src/pages/RetrainPage.jsx
+++ b/src/pages/RetrainPage.jsx
@@ -206,3 +206,4 @@ export default function RetrainPage({ before, setBefore, after, setAfter, setPag
     </>
   );
 }
+//

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -252,3 +252,4 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,"Noto Sa
 }
 @keyframes toast-in { from { transform: translateX(100%); opacity: 0;} to { transform: translateX(0); opacity: 1;}}
 @keyframes toast-out { from { transform: translateX(0); opacity: 1;} to {transform: translateX(100%); opacity: 0;}}
+/**/


### PR DESCRIPTION
- '수정 전'/'수정 후' 탭 전환 기능 구현

- onSave/onUndo 함수를 통해 데이터 목록 간 이동 로직 구현

## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
Issue #7

---

## ✨ 변경 내용
- AI 재학습 페이지에서 '수정 전'과 '수정 후' 탭으로 데이터를 나누어 볼 수 있는 UI를 구현해야 함.
- '수정하기' 버튼 클릭 시 `EmotionPicker` 모달을 여는 `onOpenEdit` 로직을 구현해야 함.
- 모달에서 '저장하기'를 누르면, 해당 항목을 '수정 전' 목록에서 '수정 후' 목록으로 이동시키는 `onSave` 함수를 구현해야 함. 이 과정에서 원본 데이터는 `__origin` 키에 백업해야 함.
- '수정 후' 목록의 '되돌리기' 버튼 클릭 시, 백업된 원본 데이터로 항목을 복원하여 '수정 전' 목록으로 되돌리는 `onUndo` 함수를 구현해야 함.

---

## 🧪 테스트 방법
- [ ] **1. 수정/저장 테스트**: AI 재학습 페이지(`/ai_retrain`)로 이동하여, '수정 전' 탭의 목록 중 하나에 있는 **수정 아이콘**을 클릭해야 함.
- [ ] **2. 데이터 이동 확인**: `EmotionPicker` 모달이 뜨면 감정을 몇 개 변경하고 '저장하기' 버튼을 클릭해야 함. 모달이 닫히면서 **'수정 후' 탭으로 자동 전환**되고, 방금 수정한 항목이 목록 맨 위에 나타나는지 확인해야 함. '수정 전' 탭으로 돌아가면 해당 항목이 사라졌는지 확인해야 함.
- [ ] **3. 되돌리기 테스트**: '수정 후' 탭에 있는 항목의 **되돌리기 아이콘**을 클릭해야 함.
- [ ] **4. 데이터 복원 확인**: **'수정 전' 탭으로 자동 전환**되고, 해당 항목이 원래의 감정 데이터를 가진 상태로 다시 나타나는지 확인해야 함.

---

## 👀 리뷰 포인트
- `RetrainPage.jsx`에서 `tab` 상태에 따라 `list` 변수에 `before` 또는 `after` 배열을 할당하는 동적 렌더링 로직을 검토해야 함.
- `onSave` 함수에서 `__origin` 키에 원본 데이터를 백업하고, `setBefore`와 `setAfter`를 사용하여 두 상태 배열 간에 데이터를 이동시키는 로직을 중점적으로 검토해야 함.
- `onUndo` 함수에서 `__origin` 키를 사용하여 데이터를 복원하고, 다시 `setAfter`와 `setBefore`를 통해 상태를 되돌리는 로직이 올바르게 구현되었는지 확인해야 함.

---

## 📎 기타 참고 사항
- 이번 PR은 **4개 파일(`RetrainPage.jsx`, `App.jsx`, `data.jsx`, `index.css`)** 에 대한 변경사항만을 포함해야 함. (`EmotionPicker.jsx`는 별도 이슈로 다룸)
- 모든 데이터 이동 및 수정은 API 연동 없이 `data.jsx` 파일의 더미 데이터를 기반으로 **클라이언트 사이드에서만** 동작함.
 - 재학습해야하는 데이터를 어떻게 가져와야하는지 모르겠음...