### PR TITLE
[Feat] 기존 관리자 계정의 비밀번호 재설정 및 임시 비밀번호 재발급 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -166,3 +166,4 @@ export default function App() {
     </ToastProvider>
   );
 }
+//

--- a/src/Data/data.jsx
+++ b/src/Data/data.jsx
@@ -163,3 +163,4 @@ export const generateDummyLogs = (userId) => {
     };
   }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp)); // 생성된 로그를 최신순으로 정렬함.
 };
+//

--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -54,3 +54,4 @@ export function ToastProvider({ children }) {
     </ToastContext.Provider>
   );
 }
+//

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -328,3 +328,4 @@ export default function AdminPage({ admins, setAdmins, setPageTitle }) {
     </>
   );
 }
+//

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -252,3 +252,4 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,"Noto Sa
 }
 @keyframes toast-in { from { transform: translateX(100%); opacity: 0;} to { transform: translateX(0); opacity: 1;}}
 @keyframes toast-out { from { transform: translateX(0); opacity: 1;} to {transform: translateX(100%); opacity: 0;}}
+/**/


### PR DESCRIPTION
- 비밀번호 재설정 버튼 UI 및 이벤트 핸들러 추가

- handlePasswordReset 함수를 통해 더미 데이터의 비밀번호 및 temp 상태 업데이트

## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
Issue #10

---

## ✨ 변경 내용
- 최고 관리자가 관리자 목록의 메일 아이콘을 클릭하여 특정 관리자의 비밀번호를 재설정하는 기능을 구현해야 함.
- `handlePasswordReset` 함수 내에서 `Math.random()`을 사용하여 새로운 8자리 임시 비밀번호를 생성해야 함.
- `setAdmins` 함수를 호출하여 해당 관리자의 `password`를 새 임시 비밀번호로, `temp` 속성을 `true`로 업데이트하여 다음 로그인 시 비밀번호 변경을 강제하도록 구현해야 함.
- 재설정 성공 시 사용자에게 `Toast` 피드백을 제공하고, 실제 메일 발송을 시뮬레이션하기 위해 `console.log`로 메일 내용을 출력해야 함.

---

## 🧪 테스트 방법
- [ ] **1. 재설정 기능 테스트**: 관리자 관리 페이지(`/manager`)로 이동하여, 임의의 관리자 행(예: '최성원A') 오른쪽에 있는 **메일 모양 아이콘**을 클릭해야 함.
- [ ] **2. 피드백 확인 테스트**: '임시비밀번호를 보냈습니다.' 라는 토스트 메시지가 화면에 나타나는지 확인해야 함.
- [ ] **3. 강제 변경 흐름 테스트**: **로그아웃** 후, 방금 비밀번호를 재설정한 계정(예: ID `xzv01299@gmail.com`)으로, 개발자 도구 콘솔(`F12`)에 출력된 **새로운 임시 비밀번호**를 사용하여 로그인을 시도해야 함.
- [ ] **4. 최종 확인 테스트**: 로그인 시 대시보드가 아닌 `/pswchange` 페이지로 강제 이동되는지 확인해야 함.

---

## 👀 리뷰 포인트
- `AdminPage.jsx`의 `handlePasswordReset` 함수에서 `Math.random().toString(36).substring(2, 10)`를 사용하여 임시 비밀번호를 생성하는 방식이 적절한지 검토해야 함.
- `setAdmins` 함수를 호출할 때, `map`을 사용하여 특정 관리자 객체를 찾아 `password`와 `temp` 속성을 모두 올바르게 업데이트하는 로직을 중점적으로 검토해야 함.
- 재설정된 계정으로 로그인 시, `App.jsx`의 `handleLogin` 함수가 `temp: true`를 올바르게 감지하여 리다이렉트 시키는지 확인해야 함.

---

## 📎 기타 참고 사항
- 이번 PR은 **5개 파일(`AdminPage.jsx`, `App.jsx`, `Toast.jsx`, `data.jsx`, `index.css`)** 에 대한 변경사항만을 포함해야 함.
- 실제 이메일 발송 기능은 구현되지 않았으며, `console.log`를 통한 시뮬레이션만 포함됨. 모든 데이터 조작은 API 연동 없이 더미 데이터를 기반으로 클라이언트 사이드에서만 동작함.
- 정확히 어디서 하는건지 몰라서 일단 프론트에서 코딩을 이렇게는 해놓음.