### PR TITLE
[Feat] 관리자 목록 조회, 검색 및 권한 해제 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -166,3 +166,4 @@ export default function App() {
     </ToastProvider>
   );
 }
+//

--- a/src/Data/data.jsx
+++ b/src/Data/data.jsx
@@ -163,3 +163,4 @@ export const generateDummyLogs = (userId) => {
     };
   }).sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp)); // 생성된 로그를 최신순으로 정렬함.
 };
+//

--- a/src/pages/AdminPage.jsx
+++ b/src/pages/AdminPage.jsx
@@ -328,3 +328,4 @@ export default function AdminPage({ admins, setAdmins, setPageTitle }) {
     </>
   );
 }
+//

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -252,3 +252,4 @@ body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,"Noto Sa
 }
 @keyframes toast-in { from { transform: translateX(100%); opacity: 0;} to { transform: translateX(0); opacity: 1;}}
 @keyframes toast-out { from { transform: translateX(0); opacity: 1;} to {transform: translateX(100%); opacity: 0;}}
+/**/


### PR DESCRIPTION
- App.jsx에서 최고 관리자 전용 접근 제어 로직 구현

- AdminPage.jsx에 클라이언트 사이드 검색 기능 구현

- 확인 모달을 포함한 관리자 권한 해제(삭제) 기능 구현

## 🔗 관련 이슈
해당 PR이 연결되는 이슈 번호를 명시하세요.  
Issue #11

---

## ✨ 변경 내용
- 최고 관리자(`root`)만 `/manager` 경로에 접근할 수 있도록 `App.jsx`에 라우팅 가드를 구현해야 함.
- `AdminPage.jsx`에서 관리자 목록을 표시하고, 닉네임 기반으로 목록을 실시간으로 필터링하는 검색 기능을 구현해야 함.
- '권한 해제' 버튼 클릭 시, 사용자에게 재확인하는 `ConfirmationDialog` 모달을 띄우고, '확인' 클릭 시 해당 관리자를 목록에서 제거하는 기능을 구현해야 함.

---

## 🧪 테스트 방법
- [ ] **1. 접근 제어 테스트 (성공)**: 최고 관리자 계정(`compasstep`/`compasstep`)으로 로그인 후, 사이드바의 '관리자 관리' 메뉴를 클릭했을 때 `/manager` 페이지로 정상 이동하는지 확인해야 함.
- [ ] **2. 접근 제어 테스트 (실패)**: 일반 관리자 계정(`xzv01299@gmail.com`/`password1`)으로 로그인 후, 브라우저 주소창에 `/manager`를 직접 입력했을 때 대시보드(`/`)로 튕겨내는지 확인해야 함.
- [ ] **3. 검색 기능 테스트**: 관리자 관리 페이지에서 검색창에 특정 관리자의 닉네임 일부(예: '최성원')를 입력했을 때, 목록이 해당 닉네임을 포함하는 관리자만으로 실시간 필터링되는지 확인해야 함.
- [ ] **4. 권한 해제 테스트**: 임의의 관리자 행에서 '권한 해제' 버튼을 클릭했을 때, "권한을 해제하시겠습니까?" 라는 확인 모달이 나타나는지 확인해야 함. '확인' 버튼을 클릭하면 해당 관리자가 목록에서 사라지는지 확인해야 함.

---

## 👀 리뷰 포인트
- `App.jsx`의 라우팅 설정에서 `userRole === 'root'` 삼항 연산자를 사용하여 최고 관리자 전용 페이지 접근을 제어하는 방식이 올바른지 검토해야 함.
- `AdminPage.jsx`에서 `useMemo`를 사용하여 `admins` 배열을 `searchTerm`에 따라 필터링하는 클라이언트 사이드 검색 로직을 중점적으로 검토해야 함.
- `handleRevokeClick`과 `handleConfirmRevoke` 함수를 통해 `adminToRevoke`와 `isConfirmOpen` 상태를 제어하며 권한 해제 흐름을 관리하는 방식이 적절한지 확인해야 함.

---

## 📎 기타 참고 사항
- 이번 PR은 **4개 파일(`AdminPage.jsx`, `App.jsx`, `data.jsx`, `index.css`)** 에 대한 변경사항만을 포함해야 함.
- 모든 데이터 조작(검색, 삭제)은 API 연동 없이 `data.jsx` 파일의 더미 데이터를 기반으로 **클라이언트 사이드에서만** 동작함.